### PR TITLE
add the ability to log programatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The following functions are available on the initialization function:
 - `flush()` Will force a a call to the flush function defined during initialization. Note that if there are no records in memory, this will not do anything.
 - `setLogLevel(string)` Sets the log level for Varnus. May be one of `off`|`trace`|`debug`|`info`.
 - `logEnabled(string)` Returns `true` if the given log level is enabled. For instance, if the log level is `debug`, then `logEnabled('info')` will return `true`, while `logEnabled('trace')` will return `false`.
+- `getLogger(name, defaultLevel)` Returns a function _log(logName, start, end, level)_ that can be used to programmatically log timings. The returned item also has _info_, _trace_, and _debug_ methods attached allowing you to log at the required level.
+- `levels` The map of log levels supported, e.g _levels.info_ can be passed where required to log at info level.
 
 ### Monitors
 Monitors are created by calling `newMonitor(string)` on a Varanaus instance. They are used to wrap functions to be monitored, and can manually log times if necessary.
@@ -159,4 +161,20 @@ function foo(cb) {
     cb(err, result);
   });
 }
+```
+
+### Loggers
+For most use cases wrapping functions with a monitor is the easiest approach, but if you'd like to programmatically use varanus then a logger instance can facilitate that. Loggers expose functionality to log timing without the need for wrapping functions.
+
+```js
+var logger = varanus.getLogger('timings', varanus.levels.info);
+
+var start = Date.now();
+
+performSlowOperation()
+  .then(function () {
+    // Passing the end time is optional, if you omit it, varanus will insert it
+    var end = Date.now();
+    logger.info('my-custom-timer', start, end);
+  });;
 ```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var x51 = require('x51');
+var assert = require('assert');
 
 var LEVEL_MAP = {
   trace: 10,
@@ -33,7 +34,9 @@ module.exports = function(opts) {
     newMonitor: newMonitor,
     flush: flush,
     setLogLevel: setLogLevel,
-    logEnabled: logEnabled
+    logEnabled: logEnabled,
+    getLogger: getLogger,
+    levels: LEVEL_MAP
   };
 
   return self;
@@ -152,6 +155,35 @@ module.exports = function(opts) {
 
       }
     };
+  }
+
+  /**
+   * Returns a logger that can be used programmatically.
+   * @param  {String}   name
+   * @param  {Number}   defaultLevel
+   * @return {Function}
+   */
+  function getLogger (name, defaultLevel) {
+    assert.equal(typeof name, 'string', 'getLogger expects a logger name');
+    assert.notEqual(name.length, 0, 'getLogger expects a logger name');
+
+    defaultLevel = defaultLevel || _level;
+
+    function _log (fnName, start, end, lvl) {
+      lvl = lvl || defaultLevel;
+      end = end || Date.now();
+
+      _logTime(name, lvl, fnName, start, end);
+    }
+
+    // Add methods for each log level, (info, trace, debug)
+    Object.keys(LEVEL_MAP).forEach(function (key) {
+      _log[key] = function (fnName, start, end) {
+        _log(fnName, start, end, LEVEL_MAP[key]);
+      };
+    });
+
+    return _log;
   }
 
   function _logTime(monitorName, logLevel, fnName, startTime, endTime, params) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "varanus",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Tool for sending performance monitoring metrics",
   "main": "index.js",
   "scripts": {
@@ -16,12 +16,16 @@
     "performance"
   ],
   "author": "MikeyBurkman",
+  "contributors": [{
+    "name": "Evan Shortiss"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/MikeyBurkman/varanus/issues"
   },
   "homepage": "https://github.com/MikeyBurkman/varanus#readme",
   "dependencies": {
+    "on-finished": "~2.3.0",
     "x51": "^2.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -551,4 +551,34 @@ describe(__filename, function() {
     });
   });
 
+  describe('#getLogger', function () {
+    it('should return a logger instance and write a log', function () {
+      var flush = sinon.stub();
+
+      var varanus = mod({
+        flush: flush,
+        level: 'info'
+      });
+
+      var name = 'test-logger';
+      var operation = 'test-operation';
+      var log = varanus.getLogger(name);
+      var start = Date.now();
+
+      expect(log.info).to.be.a('function');
+
+      log(operation, start);
+
+      varanus.flush();
+
+      expect(flush.callCount).to.eql(1);
+      var items = flush.getCall(0).args[0];
+      expect(items.length).to.eql(1);
+
+      expect(items[0].service).to.equal(name);
+      expect(items[0].fnName).to.equal(operation);
+      expect(items[0].time).to.be.a('number');
+    });
+  });
+
 });


### PR DESCRIPTION
I'm thinking this could be useful for building generic logging interfaces around varanus, e.g express middleware, or an application specific logger that uses events. 

Also, hacktoberfest.
